### PR TITLE
Fixed fadeDist locking out UI on low values

### DIFF
--- a/Packages/com.mattshark.openflight/Runtime/Scripts/UI/OpenFlightTablet.cs
+++ b/Packages/com.mattshark.openflight/Runtime/Scripts/UI/OpenFlightTablet.cs
@@ -93,7 +93,7 @@ namespace OpenFlightVRC.UI
 			if (_fadeTimeout <= 0)
 			{
 				//check if the player is within the fade distance
-				if (_localPlayer.IsValid() && Vector3.Distance(_localPlayer.GetPosition(), transform.position) > fadeDistance && allowFade)
+				if (_localPlayer.IsValid() && Vector3.Distance(_localPlayer.GetTrackingData(VRCPlayerApi.TrackingDataType.Head).position, transform.position) > fadeDistance && allowFade)
 				{
 					//disable all the objects that should be hidden
 					SetFadeState(false);


### PR DESCRIPTION
Setting fadeDist to 1 in the UI can effectively brick the UI as the player position refers to the avatar root, not the head. This can make it impossible to reduce the distance to less than 1 and may require rejoining the world to fix.

This change compares against the actual head position instead so that the user can intuitively move closer to the UI and make it functional again.